### PR TITLE
10 refactor responses and underlying structs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@
 
 # Go workspace file
 go.work
+
+# Environment files
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
 # wyebot-go
+
+## Usage
+
+Create ".env".
+```bash
+touch .env
+```
+Update values below in ".env" to be able to run integration tests.
+```bash
+WYEBOT_URL=WYEBOT_API_URL # (string) cloud name by looking at the address bar in your browser when logged into the Wyebot dashboard.
+WYEBOT_API_KEY=WYEBOT_API_KEY # (string) This can be done from the Management-> API Key. Only dashboard Administrators can generate API Keys.
+WYEBOT_LOCATION_ID=1111 # (int) Sample Location ID.
+WYEBOT_SENSOR_ID=2222 # (int) Sample Wyebot Sensor ID.
+```
+
+Export environment variables.
+```bash
+export $(cat .env)
+```
+
+Run integrations tests.
+```bash
+go test -v -tags=integration
+```

--- a/access_point_list.go
+++ b/access_point_list.go
@@ -19,11 +19,11 @@ type AccessPointDetails struct {
 	Vendor             string `json:"vendor"`
 	ClassificationType int    `json:"classification_type"`
 }
-type AccessPointDetailsResponse struct {
-	AccessPointDetails []AccessPointDetails `json:"data"`
+type AccessPointsDetailsResponse struct {
+	Data []AccessPointDetails `json:"data"`
 }
 
-func (c *Client) GetAccessPointList(ctx context.Context, sensor_id int) (*AccessPointDetailsResponse, error) {
+func (c *Client) GetAccessPointList(ctx context.Context, sensor_id int) (*AccessPointsDetailsResponse, error) {
 	body := map[string]int{"sensor_id": sensor_id}
 	jsonBody, _ := json.Marshal(body)
 
@@ -33,7 +33,7 @@ func (c *Client) GetAccessPointList(ctx context.Context, sensor_id int) (*Access
 	}
 
 	req.Header.Set("Content-Type", "application/json; charset=utf-8")
-	res := AccessPointDetailsResponse{}
+	res := AccessPointsDetailsResponse{}
 	if err := c.sendRequest(ctx, req, &res, "access_point_details"); err != nil {
 		return nil, err
 	}

--- a/integration_test.go
+++ b/integration_test.go
@@ -6,18 +6,19 @@ package wyebot
 import (
 	"context"
 	"os"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-const (
-	LocationID = 3094
-	SensorID   = 30940001
-)
+var BaseUrl = os.Getenv("WYEBOT_URL")
+var ApiKey = os.Getenv("WYEBOT_API_KEY")
+var LocationID, _ = strconv.Atoi(os.Getenv("WYEBOT_LOCATION_ID"))
+var SensorID, _ = strconv.Atoi(os.Getenv("WYEBOT_SENSOR_ID"))
 
 func TestGetLocations(t *testing.T) {
-	c := NewClient(os.Getenv("WYEBOT_INTEGRATION_API_KEY"), "https://eu-cloud.wyebot.com")
+	c := NewClient(ApiKey, BaseUrl)
 
 	ctx := context.Background()
 	res, err := c.GetLocations(ctx)
@@ -26,7 +27,7 @@ func TestGetLocations(t *testing.T) {
 }
 
 func TestGetSensors(t *testing.T) {
-	c := NewClient(os.Getenv("WYEBOT_INTEGRATION_API_KEY"), "https://eu-cloud.wyebot.com")
+	c := NewClient(ApiKey, BaseUrl)
 
 	ctx := context.Background()
 	res, err := c.GetSensors(ctx, LocationID)
@@ -35,7 +36,7 @@ func TestGetSensors(t *testing.T) {
 }
 
 func TestGetSensorInfo(t *testing.T) {
-	c := NewClient(os.Getenv("WYEBOT_INTEGRATION_API_KEY"), "https://eu-cloud.wyebot.com")
+	c := NewClient(ApiKey, BaseUrl)
 
 	ctx := context.Background()
 	res, err := c.GetSensorInfo(ctx, SensorID)
@@ -44,7 +45,7 @@ func TestGetSensorInfo(t *testing.T) {
 }
 
 func TestGetSensorIssues(t *testing.T) {
-	c := NewClient(os.Getenv("WYEBOT_INTEGRATION_API_KEY"), "https://eu-cloud.wyebot.com")
+	c := NewClient(ApiKey, BaseUrl)
 
 	ctx := context.Background()
 	res, err := c.GetSensorIssues(ctx, SensorID)
@@ -53,7 +54,7 @@ func TestGetSensorIssues(t *testing.T) {
 }
 
 func TestGetSensorNetworkInfo(t *testing.T) {
-	c := NewClient(os.Getenv("WYEBOT_INTEGRATION_API_KEY"), "https://eu-cloud.wyebot.com")
+	c := NewClient(ApiKey, BaseUrl)
 
 	ctx := context.Background()
 	res, err := c.GetSensorNetworkInfo(ctx, SensorID)
@@ -62,7 +63,7 @@ func TestGetSensorNetworkInfo(t *testing.T) {
 }
 
 func TestGetAccessPointList(t *testing.T) {
-	c := NewClient(os.Getenv("WYEBOT_INTEGRATION_API_KEY"), "https://eu-cloud.wyebot.com")
+	c := NewClient(ApiKey, BaseUrl)
 
 	ctx := context.Background()
 	res, err := c.GetAccessPointList(ctx, SensorID)
@@ -71,7 +72,7 @@ func TestGetAccessPointList(t *testing.T) {
 }
 
 func TestGetNetworkTestProfiles(t *testing.T) {
-	c := NewClient(os.Getenv("WYEBOT_INTEGRATION_API_KEY"), "https://eu-cloud.wyebot.com")
+	c := NewClient(ApiKey, BaseUrl)
 
 	ctx := context.Background()
 	res, err := c.GetNetworkTestProfiles(ctx, LocationID)
@@ -80,7 +81,7 @@ func TestGetNetworkTestProfiles(t *testing.T) {
 }
 
 func TestGetRfDetails(t *testing.T) {
-	c := NewClient(os.Getenv("WYEBOT_INTEGRATION_API_KEY"), "https://eu-cloud.wyebot.com")
+	c := NewClient(ApiKey, BaseUrl)
 
 	ctx := context.Background()
 	res, err := c.GetRfDetails(ctx, SensorID)
@@ -89,7 +90,7 @@ func TestGetRfDetails(t *testing.T) {
 }
 
 func TestNetworkTestResults(t *testing.T) {
-	c := NewClient(os.Getenv("WYEBOT_INTEGRATION_API_KEY"), "https://eu-cloud.wyebot.com")
+	c := NewClient(ApiKey, BaseUrl)
 
 	ctx := context.Background()
 	res, err := c.GetNetworkTestResults(ctx, 3094, 3641, "2021-02-21 00:40:00", "2024-01-10 21:00:00")

--- a/locations.go
+++ b/locations.go
@@ -6,8 +6,8 @@ import (
 	"net/http"
 )
 
-type LocationList struct {
-	Locations []Location `json:"data"`
+type LocationsResponse struct {
+	Data []Location `json:"data"`
 }
 
 type Location struct {
@@ -15,7 +15,7 @@ type Location struct {
 	LocationName string `json:"location_name"`
 }
 
-func (c *Client) GetLocations(ctx context.Context) (*LocationList, error) {
+func (c *Client) GetLocations(ctx context.Context) (*LocationsResponse, error) {
 
 	req, err := http.NewRequest("GET", fmt.Sprintf("%s/external_api/org/get_locations", c.baseURL), nil)
 	if err != nil {
@@ -24,7 +24,7 @@ func (c *Client) GetLocations(ctx context.Context) (*LocationList, error) {
 
 	req.Header.Set("Content-Type", "application/json; charset=utf-8")
 
-	res := LocationList{}
+	res := LocationsResponse{}
 	if err := c.sendRequest(ctx, req, &res, "location_details"); err != nil {
 		return nil, err
 	}

--- a/network_test_profiles.go
+++ b/network_test_profiles.go
@@ -20,7 +20,7 @@ type NetworkTestProfile struct {
 	IsValid        bool   `json:"is_valid"`
 }
 type NetworkTestProfilesResponse struct {
-	NetworkTestProfiles []NetworkTestProfile `json:"data"`
+	Data []NetworkTestProfile `json:"data"`
 }
 
 func (c *Client) GetNetworkTestProfiles(ctx context.Context, location_id int) (*NetworkTestProfilesResponse, error) {

--- a/network_test_results.go
+++ b/network_test_results.go
@@ -20,7 +20,7 @@ type NetworkTestResult struct {
 	ExecutionID          int    `json:"execution_id"`
 }
 type NetworkTestResultsResponse struct {
-	NetworkTestResults []NetworkTestResult `json:"data"`
+	Data []NetworkTestResult `json:"data"`
 }
 
 func (c *Client) GetNetworkTestResults(ctx context.Context, location_id int, net_test_profile_id int, start string, end string) (*NetworkTestResultsResponse, error) {

--- a/rf_details.go
+++ b/rf_details.go
@@ -21,7 +21,7 @@ type RfAnalyticsRadio0 struct {
 	//ClientHostnameList      []string `json:"client_hostname_list"`
 	ClientAirtimePercentage string `json:"client_airtime_percentage"`
 }
-type RfAnalyticsRadio1 struct {
+type RfAnalyticsRadio struct {
 	OutChannel          string `json:"out_channel"`
 	AirtimeTotalPercent string `json:"airtime_total_percent"`
 	MgmtPercent         string `json:"mgmt_percent"`
@@ -35,12 +35,12 @@ type RfAnalyticsRadio1 struct {
 	ClientAirtimePercentage string `json:"client_airtime_percentage"`
 }
 type RfDetails struct {
-	RfAnalyticsRadio0 RfAnalyticsRadio0 `json:"rf_analytics_radio_0"`
-	RfAnalyticsRadio1 RfAnalyticsRadio1 `json:"rf_analytics_radio_1"`
+	Radio0 RfAnalyticsRadio `json:"rf_analytics_radio_0"`
+	Radio1 RfAnalyticsRadio `json:"rf_analytics_radio_1"`
 }
 
 type RfDetailsResponse struct {
-	RfDetails RfDetails `json:"data"`
+	Data RfDetails `json:"data"`
 }
 
 func (c *Client) GetRfDetails(ctx context.Context, sensor_id int) (*RfDetailsResponse, error) {

--- a/sensor_info.go
+++ b/sensor_info.go
@@ -106,17 +106,17 @@ type HardwareDetails struct {
 	Service       Service       `json:"service"`
 	//LldpInfo      LldpInfo      `json:"lldp_info"`
 }
-type Data struct {
+type SensorInfo struct {
 	SensorID         int             `json:"sensor_id"`
 	SensorName       string          `json:"sensor_name"`
 	SensorStatusName string          `json:"sensor_status_name"`
 	HardwareDetails  HardwareDetails `json:"hardware_details"`
 }
-type SensorInfo struct {
-	SensorInfo Data `json:"data"`
+type SensorsInfoResponse struct {
+	Data SensorInfo `json:"data"`
 }
 
-func (c *Client) GetSensorInfo(ctx context.Context, sensor_id int) (*SensorInfo, error) {
+func (c *Client) GetSensorInfo(ctx context.Context, sensor_id int) (*SensorsInfoResponse, error) {
 	body := map[string]int{"sensor_id": sensor_id}
 	jsonBody, _ := json.Marshal(body)
 
@@ -126,7 +126,7 @@ func (c *Client) GetSensorInfo(ctx context.Context, sensor_id int) (*SensorInfo,
 	}
 
 	req.Header.Set("Content-Type", "application/json; charset=utf-8")
-	res := SensorInfo{}
+	res := SensorsInfoResponse{}
 	if err := c.sendRequest(ctx, req, &res, "sensor_info"); err != nil {
 		return nil, err
 	}

--- a/sensor_issues.go
+++ b/sensor_issues.go
@@ -14,11 +14,11 @@ type Issue struct {
 	ProblemDescription string `json:"problem_description"`
 	Solution           string `json:"solution"`
 }
-type IssueList struct {
-	Issues []Issue `json:"data"`
+type IssuesResponse struct {
+	Data []Issue `json:"data"`
 }
 
-func (c *Client) GetSensorIssues(ctx context.Context, sensor_id int) (*IssueList, error) {
+func (c *Client) GetSensorIssues(ctx context.Context, sensor_id int) (*IssuesResponse, error) {
 	body := map[string]int{"sensor_id": sensor_id}
 	jsonBody, _ := json.Marshal(body)
 
@@ -28,7 +28,7 @@ func (c *Client) GetSensorIssues(ctx context.Context, sensor_id int) (*IssueList
 	}
 
 	req.Header.Set("Content-Type", "application/json; charset=utf-8")
-	res := IssueList{}
+	res := IssuesResponse{}
 	if err := c.sendRequest(ctx, req, &res, "issue_details"); err != nil {
 		return nil, err
 	}

--- a/sensor_net_info.go
+++ b/sensor_net_info.go
@@ -21,7 +21,7 @@ type SensorNetworkInfo struct {
 	DNS2             string `json:"dns2"`
 }
 type SensorNetWorkInfoResponse struct {
-	SensorNetworkInfo SensorNetworkInfo `json:"data"`
+	Data SensorNetworkInfo `json:"data"`
 }
 
 func (c *Client) GetSensorNetworkInfo(ctx context.Context, sensor_id int) (*SensorNetWorkInfoResponse, error) {

--- a/sensors.go
+++ b/sensors.go
@@ -8,8 +8,8 @@ import (
 	"net/http"
 )
 
-type SensorList struct {
-	Sensors []Sensor `json:"data"`
+type SensorsResponse struct {
+	Data []Sensor `json:"data"`
 }
 
 type Sensor struct {
@@ -17,7 +17,7 @@ type Sensor struct {
 	SensorName string `json:"sensor_name"`
 }
 
-func (c *Client) GetSensors(ctx context.Context, location_id int) (*SensorList, error) {
+func (c *Client) GetSensors(ctx context.Context, location_id int) (*SensorsResponse, error) {
 	body := map[string]int{"location_id": location_id}
 	jsonBody, _ := json.Marshal(body)
 
@@ -27,7 +27,7 @@ func (c *Client) GetSensors(ctx context.Context, location_id int) (*SensorList, 
 	}
 
 	req.Header.Set("Content-Type", "application/json; charset=utf-8")
-	res := SensorList{}
+	res := SensorsResponse{}
 	if err := c.sendRequest(ctx, req, &res, "sensor_details"); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Seems legit 
```bash
❯ go test -v -tags=integration
=== RUN   TestGetLocations
--- PASS: TestGetLocations (0.23s)
=== RUN   TestGetSensors
--- PASS: TestGetSensors (0.13s)
=== RUN   TestGetSensorInfo
--- PASS: TestGetSensorInfo (0.14s)
=== RUN   TestGetSensorIssues
--- PASS: TestGetSensorIssues (0.13s)
=== RUN   TestGetSensorNetworkInfo
--- PASS: TestGetSensorNetworkInfo (0.13s)
=== RUN   TestGetAccessPointList
--- PASS: TestGetAccessPointList (0.13s)
=== RUN   TestGetNetworkTestProfiles
--- PASS: TestGetNetworkTestProfiles (0.13s)
=== RUN   TestGetRfDetails
--- PASS: TestGetRfDetails (0.14s)
=== RUN   TestNetworkTestResults
--- PASS: TestNetworkTestResults (0.14s)
PASS
ok      github.com/emilvonck/wyebot-go  1.507s
```